### PR TITLE
run app as the non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,31 +4,47 @@ ENV HOST localhost
 ENV PORT 3000
 
 # Create app directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+RUN mkdir -p /home/docker_user
+
+# Create an app user so the program doesn't run as root.
+RUN groupadd -r docker_user &&\
+  useradd -r -g docker_user -d /home/docker_user -s /sbin/nologin -c "Docker image user" docker_user
+
+# Setting up the app
+ENV APP_HOME=/home/docker_user/app
+RUN mkdir $APP_HOME
+WORKDIR ${APP_HOME}
+
 
 # Install GYP dependencies globally, will be used to code build other dependencies
 RUN npm install -g --production node-gyp && \
-    npm cache clean --force
+  npm cache clean --force
 
 # Install Gekko dependencies
 COPY package.json .
 RUN npm install --production && \
-    npm install --production redis@0.10.0 talib@1.0.2 tulind@0.8.7 pg && \
-    npm cache clean --force
+  npm install --production redis@0.10.0 talib@1.0.2 tulind@0.8.7 pg && \
+  npm cache clean --force
 
 # Install Gekko Broker dependencies
 WORKDIR exchange
 COPY exchange/package.json .
 RUN npm install --production && \
-    npm cache clean --force
+  npm cache clean --force
 WORKDIR ../
 
 # Bundle app source
-COPY . /usr/src/app
+COPY . ${APP_HOME}
+
+# Chown all the files to the app user.
+RUN chown -R docker_user:docker_user $APP_HOME
 
 EXPOSE 3000
-RUN chmod +x /usr/src/app/docker-entrypoint.sh
-ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
+# change to the docker_user
+USER docker_user
+
+RUN chmod +x ${APP_HOME}/docker-entrypoint.sh
+# runs the app as the docker_user
+ENTRYPOINT ["/home/docker_user/app/docker-entrypoint.sh"]
 
 CMD ["--config", "config.js", "--ui"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-sed -i 's/127.0.0.1/0.0.0.0/g' /usr/src/app/web/vue/dist/UIconfig.js
-sed -i 's/localhost/'${HOST}'/g' /usr/src/app/web/vue/dist/UIconfig.js
-sed -i 's/3000/'${PORT}'/g' /usr/src/app/web/vue/dist/UIconfig.js
+sed -i 's/127.0.0.1/0.0.0.0/g' /home/docker_user/app/web/vue/dist/UIconfig.js
+sed -i 's/localhost/'${HOST}'/g' /home/docker_user/app/web/vue/dist/UIconfig.js
+sed -i 's/3000/'${PORT}'/g' /home/docker_user/app/web/vue/dist/UIconfig.js
 if [[ "${USE_SSL:-0}" == "1" ]] ; then
-    sed -i 's/ssl: false/ssl: true/g' /usr/src/app/web/vue/dist/UIconfig.js
+    sed -i 's/ssl: false/ssl: true/g' /home/docker_user/app/web/vue/dist/UIconfig.js
 fi
 exec node gekko "$@"


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
The changes in this PR are security related changes.

By default, Docker Containers run as Root Users. This poses a great security threat when you deploy applications to a network due to a sleuth of related attacks. 


* **What is the new behavior (if this is a feature change)?**
This new code will change the behavior of the app, by now running the app as the docker_user and not the root user.
Nothing should change in the functionality. 

* **Other information**:
How to get these changes:
```
1. git remote add upstream  https://github.com:bmaca/gekko.git
2. git remote pull upstream develop
```

Once the changes are pulled in, you can now run the app with:
```
# remove orphans remove containers for services not defined in the Compose file.
docker-compose up --build --remove-orphans
```

